### PR TITLE
Plugin not working (extract) with CakePHP 2.10.15

### DIFF
--- a/Console/Command/Task/ExtractJsTask.php
+++ b/Console/Command/Task/ExtractJsTask.php
@@ -65,7 +65,7 @@ class ExtractJsTask extends ExtractTask {
 
 		// todo: not only webroot
 		$dir = new Folder(APP);
-		$files = $dir->findRecursive('^([a-zA-Z0-9\s_\\.\-\(\):])+\.(js|ctp)$');
+		$files = $dir->findRecursive('.+\.(js|ctp)$');
 		foreach ($files as $filepath) {
 			$this->_locale_parse_js_file($filepath);
 		}

--- a/Console/Command/Task/ExtractJsTask.php
+++ b/Console/Command/Task/ExtractJsTask.php
@@ -65,7 +65,7 @@ class ExtractJsTask extends ExtractTask {
 
 		// todo: not only webroot
 		$dir = new Folder(APP);
-		$files = $dir->findRecursive('.js|.ctp');
+		$files = $dir->findRecursive('^([a-zA-Z0-9\s_\\.\-\(\):])+\.(js|ctp)$');
 		foreach ($files as $filepath) {
 			$this->_locale_parse_js_file($filepath);
 		}


### PR DESCRIPTION
The plugin doesn't find any js or ctp files. $dir->findRecursive returns an empty array.
I've changed the regex to match files with js or ctp extension. i18n_js.pot file is now generated correctly.