### PR TITLE
Warning for phpv7 compatibility

### DIFF
--- a/Lib/PoParser.php
+++ b/Lib/PoParser.php
@@ -172,7 +172,7 @@ class PoParser {
 							break;
 					}
 
-					continue;
+					continue 2;
 
 				// context
 				// Allows disambiguations of different messages that have same msgid.


### PR DESCRIPTION
The warning is : "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
in \I18nJs\Lib\PoParser.php on line 175